### PR TITLE
Add CHANGELOG entry for v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.2.1
+
+### Bug fixes
+
+- Reject authorization requests where `code_challenge_method` is missing. The server only supports S256, but an omitted method defaults to `plain` per RFC 7636, which silently passed authorization then failed at token exchange with a confusing `invalid_grant` error.
+
 ## v0.2.0
 
 ### Breaking changes

--- a/authorize.go
+++ b/authorize.go
@@ -137,7 +137,7 @@ func handleAuthorizeGET(w http.ResponseWriter, r *http.Request, s *store, logger
 	}
 
 	codeChallengeMethod := q.Get("code_challenge_method")
-	if codeChallengeMethod != "" && codeChallengeMethod != "S256" {
+	if codeChallengeMethod != "S256" {
 		redirectWithError(w, r, redirectURI, state, "invalid_request", "only S256 code_challenge_method is supported")
 		return
 	}

--- a/handler_test.go
+++ b/handler_test.go
@@ -1071,7 +1071,7 @@ func TestAuthorize_GET_ShowsLoginForm(t *testing.T) {
 	handler := handleAuthorize(s, users, testLogger(), testServerURL, "Sign In", "Sign in to grant access to your account.", "", nil)
 
 	challenge := pkceChallenge("test-verifier")
-	req := httptest.NewRequest("GET", "/oauth/authorize?response_type=code&client_id="+clientID+"&redirect_uri=https://example.com/callback&code_challenge="+challenge, nil)
+	req := httptest.NewRequest("GET", "/oauth/authorize?response_type=code&client_id="+clientID+"&redirect_uri=https://example.com/callback&code_challenge="+challenge+"&code_challenge_method=S256", nil)
 	rec := httptest.NewRecorder()
 
 	handler(rec, req)
@@ -1180,13 +1180,31 @@ func TestAuthorize_GET_ClickjackHeaders(t *testing.T) {
 	handler := handleAuthorize(s, users, testLogger(), testServerURL, "Sign In", "Sign in to grant access to your account.", "", nil)
 
 	challenge := pkceChallenge("test-verifier")
-	req := httptest.NewRequest("GET", "/oauth/authorize?response_type=code&client_id="+clientID+"&redirect_uri=https://example.com/callback&code_challenge="+challenge, nil)
+	req := httptest.NewRequest("GET", "/oauth/authorize?response_type=code&client_id="+clientID+"&redirect_uri=https://example.com/callback&code_challenge="+challenge+"&code_challenge_method=S256", nil)
 	rec := httptest.NewRecorder()
 
 	handler(rec, req)
 
 	assert.Equal(t, "DENY", rec.Header().Get("X-Frame-Options"))
 	assert.Equal(t, "frame-ancestors 'none'", rec.Header().Get("Content-Security-Policy"))
+}
+
+func TestAuthorize_GET_MissingCodeChallengeMethod(t *testing.T) {
+	s := testStore(t)
+	clientID := registerTestClient(t, s, []string{"https://example.com/callback"})
+	users := NewMapAuthenticator(map[string]string{"testuser": "password123"})
+	handler := handleAuthorize(s, users, testLogger(), testServerURL, "Sign In", "Sign in to grant access to your account.", "", nil)
+
+	challenge := pkceChallenge("test-verifier")
+	req := httptest.NewRequest("GET", "/oauth/authorize?response_type=code&client_id="+clientID+"&redirect_uri=https://example.com/callback&code_challenge="+challenge, nil)
+	rec := httptest.NewRecorder()
+
+	handler(rec, req)
+
+	assert.Equal(t, http.StatusFound, rec.Code)
+	location := rec.Header().Get("Location")
+	assert.Contains(t, location, "error=invalid_request")
+	assert.Contains(t, location, "code_challenge_method")
 }
 
 func TestAuthorize_GET_ResourceParameter(t *testing.T) {
@@ -1196,7 +1214,7 @@ func TestAuthorize_GET_ResourceParameter(t *testing.T) {
 	handler := handleAuthorize(s, users, testLogger(), testServerURL, "Sign In", "Sign in to grant access to your account.", "", nil)
 
 	challenge := pkceChallenge("test-verifier")
-	req := httptest.NewRequest("GET", "/oauth/authorize?response_type=code&client_id="+clientID+"&redirect_uri=https://example.com/callback&code_challenge="+challenge+"&resource="+url.QueryEscape(testServerURL), nil)
+	req := httptest.NewRequest("GET", "/oauth/authorize?response_type=code&client_id="+clientID+"&redirect_uri=https://example.com/callback&code_challenge="+challenge+"&code_challenge_method=S256&resource="+url.QueryEscape(testServerURL), nil)
 	rec := httptest.NewRecorder()
 
 	handler(rec, req)
@@ -1211,7 +1229,7 @@ func TestAuthorize_GET_WrongResource(t *testing.T) {
 	handler := handleAuthorize(s, users, testLogger(), testServerURL, "Sign In", "Sign in to grant access to your account.", "", nil)
 
 	challenge := pkceChallenge("test-verifier")
-	req := httptest.NewRequest("GET", "/oauth/authorize?response_type=code&client_id="+clientID+"&redirect_uri=https://example.com/callback&code_challenge="+challenge+"&resource=https://wrong.example.com", nil)
+	req := httptest.NewRequest("GET", "/oauth/authorize?response_type=code&client_id="+clientID+"&redirect_uri=https://example.com/callback&code_challenge="+challenge+"&code_challenge_method=S256&resource=https://wrong.example.com", nil)
 	rec := httptest.NewRecorder()
 
 	handler(rec, req)
@@ -1228,7 +1246,7 @@ func TestAuthorize_GET_LoopbackPrefixRedirect(t *testing.T) {
 	handler := handleAuthorize(s, users, testLogger(), testServerURL, "Sign In", "Sign in to grant access to your account.", "", nil)
 
 	challenge := pkceChallenge("test-verifier")
-	req := httptest.NewRequest("GET", "/oauth/authorize?response_type=code&client_id="+clientID+"&redirect_uri=http://127.0.0.1:12345&code_challenge="+challenge, nil)
+	req := httptest.NewRequest("GET", "/oauth/authorize?response_type=code&client_id="+clientID+"&redirect_uri=http://127.0.0.1:12345&code_challenge="+challenge+"&code_challenge_method=S256", nil)
 	rec := httptest.NewRecorder()
 
 	handler(rec, req)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Authorization requests without the S256 code_challenge_method parameter are now properly rejected with an `invalid_request` error, preventing downstream token exchange failures during the OAuth PKCE flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->